### PR TITLE
fix: read mapcss.ne  as utf8 string.

### DIFF
--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -29,6 +29,6 @@ function compileFunc(filename, sourceCode) {
 }
 
 const filename = "grammar/mapcss.ne";
-const grammar = fs.readFileSync(filename);
+const grammar = fs.readFileSync(filename, {encoding: 'utf8'});
 
 compileFunc(filename, grammar);


### PR DESCRIPTION
grammarParser expect string, mapcss.ne readed as buffer,
because ecoding setting not provided to fs api